### PR TITLE
Allow marking files and folder as binary patterns

### DIFF
--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -4,6 +4,14 @@
         "id": "exclude-path",
         "children": [
             {
+                "caption": "Mark as Binary in Project",
+                "id": "mark-binary-project",
+                "command": "mark_binary_project",
+                "args": {
+                    "paths": []
+                }
+            },
+            {
                 "caption": "From Project",
                 "id": "exclude-path-project",
                 "command": "exclude_path_project",


### PR DESCRIPTION
Hi, this is to allow adding files and folders as binary_file_patterns in the .sublime-project file. Binary patterns works in a similar way as file and folder exclude patterns, except that they keep the files displayed in sidebar and only hide them from search results.

Before, binary patterns could only be set globally in user config, but since build 3158 they are supported even on per project level - https://www.sublimetext.com/3dev. There are still some glitches with files not being properly excluded if a WHERE condition in used in search, but that is more a bug in Sublime3 that will hopefuly be resolved - it's tracked here: https://github.com/SublimeTextIssues/Core/issues/959

binary_file_patterns config value holds both files and folders, for folders the syntax is <folder_name>/* , which excludes all files in that folder.

I am not very proficient in Python so I will be happy for reviews or feedback. Thanks 